### PR TITLE
Update swift syntax dependency, Fix unit tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "551b9662071633ff3182608756a31bb14705bc494c4d78c684c40f2f57b812bd",
+  "originHash" : "27c942f7d59171021077354fd1a45e9a8b16bc113707ce2b33131021afc419bb",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .upToNextMajor(from: "510.0.2"))
+        .package(url: "https://github.com/apple/swift-syntax.git", .upToNextMajor(from: "601.0.1"))
     ],
     targets: [
         .macro(

--- a/Sources/SwiftNewtypeClient/main.swift
+++ b/Sources/SwiftNewtypeClient/main.swift
@@ -6,11 +6,11 @@ import SwiftNewtype
 let a = 17
 let b = 25
 
-@Newtype(Equatable, Hashable, Codable, Comparable)
+@Newtype(Equatable.self, Hashable.self, Codable.self, Comparable.self)
 @dynamicMemberLookup
 enum MyTypeAlias { case myTypeAlias(String) }
 
-@Newtype(NoConformances)
+@Newtype(NoConformances.self)
 enum ConformToNothing { case foo(String) }
 
 @Newtype
@@ -27,4 +27,6 @@ print(String(decoding: try JSONEncoder().encode(MyTypeAlias("bar")), as: UTF8.se
 print(foo.utf8)
 print(foo == MyTypeAlias("bar"))
 print(foo == .myTypeAlias("foo"))
-print(foo < .myTypeAlias("foo"))
+
+// comparable conformance for NewType wrapping Stringv values is not working at this time.
+//print(foo < .myTypeAlias("foo"))

--- a/Sources/SwiftNewtypeClient/main.swift
+++ b/Sources/SwiftNewtypeClient/main.swift
@@ -28,5 +28,5 @@ print(foo.utf8)
 print(foo == MyTypeAlias("bar"))
 print(foo == .myTypeAlias("foo"))
 
-// comparable conformance for NewType wrapping Stringv values is not working at this time.
+// comparable conformance for NewType wrapping String values is not working at this time.
 //print(foo < .myTypeAlias("foo"))

--- a/Sources/SwiftNewtypeMacros/NewtypeMacro.swift
+++ b/Sources/SwiftNewtypeMacros/NewtypeMacro.swift
@@ -14,6 +14,15 @@ public struct NewtypeMacro: MemberMacro, ExtensionMacro {
     struct Error: Swift.Error {
         let message: String
     }
+    
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo _: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        try expansion(of: node, providingMembersOf: declaration, in: context)
+    }
 
     public static func expansion(
         of node: AttributeSyntax,
@@ -35,7 +44,7 @@ public struct NewtypeMacro: MemberMacro, ExtensionMacro {
         of attribute: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo protocols: [TypeSyntax],
+        conformingTo _: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         if let enumDecl = declaration.as(EnumDeclSyntax.self) {

--- a/Tests/SwiftNewtypeTests/SwiftNewtypeTests.swift
+++ b/Tests/SwiftNewtypeTests/SwiftNewtypeTests.swift
@@ -31,7 +31,8 @@ final class MacrosTests: XCTestCase {
             
                 public subscript <T>(dynamicMember keyPath: KeyPath<String, T>) -> T {
                     value[keyPath: keyPath]
-                }}
+                }
+            }
 
             extension MyTypeAlias {
                 public init(_ value: String) {
@@ -76,7 +77,19 @@ final class MacrosTests: XCTestCase {
                         try value.encode(to: encoder)
                     }
             }
-
+            
+            extension MyTypeAlias: ExpressibleByUnicodeScalarLiteral {
+                public init(unicodeScalarLiteral: UnicodeScalarLiteralType) {
+                    self.init(String(unicodeScalarLiteral: unicodeScalarLiteral))
+                }
+            }
+            
+            extension MyTypeAlias: ExpressibleByExtendedGraphemeClusterLiteral {
+                public init(extendedGraphemeClusterLiteral value: String) {
+                    self.init(String(extendedGraphemeClusterLiteral: value))
+                }
+            }
+            
             extension MyTypeAlias: ExpressibleByStringLiteral {
                 public init(stringLiteral value: String) {
                     self.init(String(stringLiteral: value))
@@ -89,7 +102,7 @@ final class MacrosTests: XCTestCase {
                 }
             }
 
-            extension MyTypeAlias: @unchecked Sendable {
+            extension MyTypeAlias: Sendable {
             }
             """, 
             macros: testMacros
@@ -106,7 +119,8 @@ final class MacrosTests: XCTestCase {
 
                 subscript <T>(dynamicMember keyPath: KeyPath<String, T>) -> T {
                     value[keyPath: keyPath]
-                }}
+                }
+            }
 
             extension MyTypeAlias {
                 var value: String {
@@ -147,7 +161,8 @@ final class MacrosTests: XCTestCase {
 
                 public subscript <T>(dynamicMember keyPath: KeyPath<String, T>) -> T {
                     value[keyPath: keyPath]
-                }}
+                }
+            }
 
             extension MyTypeAlias {
                 public var value: String {
@@ -199,7 +214,19 @@ final class MacrosTests: XCTestCase {
                         try value.encode(to: encoder)
                     }
             }
-
+            
+            extension MyTypeAlias: ExpressibleByUnicodeScalarLiteral {
+                public init(unicodeScalarLiteral: UnicodeScalarLiteralType) {
+                    self.init(String(unicodeScalarLiteral: unicodeScalarLiteral))
+                }
+            }
+            
+            extension MyTypeAlias: ExpressibleByExtendedGraphemeClusterLiteral {
+                public init(extendedGraphemeClusterLiteral value: String) {
+                    self.init(String(extendedGraphemeClusterLiteral: value))
+                }
+            }
+            
             extension MyTypeAlias: ExpressibleByStringLiteral {
                 public init(stringLiteral value: String) {
                     self.init(String(stringLiteral: value))
@@ -212,7 +239,7 @@ final class MacrosTests: XCTestCase {
                 }
             }
 
-            extension MyTypeAlias: @unchecked Sendable {
+            extension MyTypeAlias: Sendable {
             }
             """,
             macros: testMacros
@@ -228,7 +255,8 @@ final class MacrosTests: XCTestCase {
 
                 subscript <T>(dynamicMember keyPath: KeyPath<String, T>) -> T {
                     value[keyPath: keyPath]
-                }}
+                }
+            }
 
             extension MyTypeAlias {
                 var value: String {
@@ -280,7 +308,19 @@ final class MacrosTests: XCTestCase {
                         try value.encode(to: encoder)
                     }
             }
-
+            
+            extension MyTypeAlias: ExpressibleByUnicodeScalarLiteral {
+                init(unicodeScalarLiteral: UnicodeScalarLiteralType) {
+                    self.init(String(unicodeScalarLiteral: unicodeScalarLiteral))
+                }
+            }
+            
+            extension MyTypeAlias: ExpressibleByExtendedGraphemeClusterLiteral {
+                init(extendedGraphemeClusterLiteral value: String) {
+                    self.init(String(extendedGraphemeClusterLiteral: value))
+                }
+            }
+            
             extension MyTypeAlias: ExpressibleByStringLiteral {
                 init(stringLiteral value: String) {
                     self.init(String(stringLiteral: value))
@@ -293,7 +333,7 @@ final class MacrosTests: XCTestCase {
                 }
             }
 
-            extension MyTypeAlias: @unchecked Sendable {
+            extension MyTypeAlias: Sendable {
             }
             """,
             macros: testMacros
@@ -305,7 +345,8 @@ final class MacrosTests: XCTestCase {
 
                 public subscript <T>(dynamicMember keyPath: KeyPath<String, T>) -> T {
                     value[keyPath: keyPath]
-                }}
+                }
+            }
 
             extension URLTypeAlias {
                 public var value: String {
@@ -366,7 +407,19 @@ final class MacrosTests: XCTestCase {
                         try value.encode(to: encoder)
                     }
             }
-
+            
+            extension URLTypeAlias: ExpressibleByUnicodeScalarLiteral {
+                public init(unicodeScalarLiteral: UnicodeScalarLiteralType) {
+                    self.init(String(unicodeScalarLiteral: unicodeScalarLiteral))
+                }
+            }
+            
+            extension URLTypeAlias: ExpressibleByExtendedGraphemeClusterLiteral {
+                public init(extendedGraphemeClusterLiteral value: String) {
+                    self.init(String(extendedGraphemeClusterLiteral: value))
+                }
+            }
+            
             extension URLTypeAlias: ExpressibleByStringLiteral {
                 public init(stringLiteral value: String) {
                     self.init(String(stringLiteral: value))
@@ -379,7 +432,7 @@ final class MacrosTests: XCTestCase {
                 }
             }
 
-            extension URLTypeAlias: @unchecked Sendable {
+            extension URLTypeAlias: Sendable {
             }
             """,
             macros: testMacros
@@ -484,7 +537,7 @@ final class MacrosTests: XCTestCase {
             to: "Sendable",
             expandsTo:
             """
-            extension URLTypeAlias: @unchecked Sendable {
+            extension URLTypeAlias: Sendable {
             }
             """
         )
@@ -513,7 +566,7 @@ final class MacrosTests: XCTestCase {
                 }
 
                 public func advanced(by n: Stride) -> Self {
-                    Self (value.advanced(by: n))
+                    Self(value.advanced(by: n))
                 }
             }
             """
@@ -596,8 +649,8 @@ final class MacrosTests: XCTestCase {
             expandsTo:
             """
             extension URLTypeAlias: ExpressibleByUnicodeScalarLiteral {
-                public init(unicodeScalarLiteral value: String) {
-                    self.init(String(unicodeScalarLiteral: value))
+                public init(unicodeScalarLiteral: UnicodeScalarLiteralType) {
+                    self.init(String(unicodeScalarLiteral: unicodeScalarLiteral))
                 }
             }
             """
@@ -626,7 +679,8 @@ final class MacrosTests: XCTestCase {
 
                 subscript <T>(dynamicMember keyPath: KeyPath<URL, T>) -> T {
                     value[keyPath: keyPath]
-                }}
+                }
+            }
 
             extension MyTypeAlias {
                 var value: URL {
@@ -679,7 +733,7 @@ final class MacrosTests: XCTestCase {
                     }
             }
 
-            extension MyTypeAlias: @unchecked Sendable {
+            extension MyTypeAlias: Sendable {
             }
             """,
             macros: testMacros


### PR DESCRIPTION
## Summary

This PR:
- bumps the dependency on `swift-syntax` to `601.0.1`
- resolves new warning by providing our own implementation of newly-deprecated default implementation of `static func expansion(...)`
  <img width="2822" height="232" alt="screencap_000961" src="https://github.com/user-attachments/assets/57a8f400-3d75-4e76-947a-611ec1fe00f4" />
- Fixes build errors in `main.swift` in the client target (does not fix further underlying issues)
- Fixes broken unit tests:
  <img width="800" src="https://github.com/user-attachments/assets/11dd8bf9-2222-414f-88f5-68feaac5e532" />
