### PR TITLE
Point at swiftlang github org instead of apple for the swift-syntax dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "27c942f7d59171021077354fd1a45e9a8b16bc113707ce2b33131021afc419bb",
+  "originHash" : "8d4beef6c88a0079c10b1bbace40cfde4b12f3ad4a07047a52c9014c39a36eea",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .upToNextMajor(from: "601.0.1"))
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", .upToNextMajor(from: "601.0.1"))
     ],
     targets: [
         .macro(


### PR DESCRIPTION
Point at the `swiftlang` github org instead of `apple` for the `swift-syntax` package dependency. This is the new official home of the package- so packages which depend on it need updating to prevent warnings, and eventual errors in future versions of SwiftPM.

<img width="580" height="68" alt="image" src="https://github.com/user-attachments/assets/0450fdae-98ca-4522-9a3f-d330e2d48ea7" />
