### PR TITLE
Fix lack of modifier injection into comparable conformance macro expansion

### DIFF
--- a/Sources/SwiftNewtypeMacros/Conformances/ComparableConformance.swift
+++ b/Sources/SwiftNewtypeMacros/Conformances/ComparableConformance.swift
@@ -17,7 +17,7 @@ struct ComparableConformance: Conformance {
         modifiers: DeclModifierListSyntax
     ) -> MemberBlockSyntax {
         """
-        static func < (lhs: Self, rhs: Self) -> Bool {
+        \(modifiers)static func < (lhs: Self, rhs: Self) -> Bool {
             lhs.value < rhs.value
         }
         """

--- a/Tests/SwiftNewtypeTests/SwiftNewtypeTests.swift
+++ b/Tests/SwiftNewtypeTests/SwiftNewtypeTests.swift
@@ -667,6 +667,18 @@ final class MacrosTests: XCTestCase {
             }
             """
         )
+        
+        assertConformance(
+            to: "Comparable",
+            expandsTo:
+            """
+            extension URLTypeAlias: Comparable {
+                public static func < (lhs: Self, rhs: Self) -> Bool {
+                    lhs.value < rhs.value
+                }
+            }
+            """
+        )
 
         assertMacroExpansion(
             """


### PR DESCRIPTION
Implementation was missing `\(modifiers)` in the string interpolation for the `ComparableConformance`. 

Tests updated as well.